### PR TITLE
Accumulating one line per section.

### DIFF
--- a/varnish.go
+++ b/varnish.go
@@ -15,6 +15,11 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
+const (
+	kwAll = "all"
+)
+
+// Varnish is used to store configuration values
 type Varnish struct {
 	Stats []string `toml:"stats"`
 }
@@ -23,44 +28,50 @@ func (s *Varnish) Description() string {
 	return "a plugin to collect stats from varnish"
 }
 
+var defaultStats = []string{"MAIN.cache_hit", "MAIN.cache_miss", "MAIN.uptime"}
+
 var varnishSampleConfig = `
   ## By default, telegraf gather stats for 3 metric points.
   ## Setting stats will remove the defaults
-  stats = ['MAIN.cache_hit', 'MAIN.cache_miss', 'MAIN.uptime']
+  stats = %v
+
+  ## Use the keyword 'all' to include everything
+  stats = ['%s']
 `
 
+// SampleConfig displays configuration instructions
 func (s *Varnish) SampleConfig() string {
-	return varnishSampleConfig
+	return fmt.Sprintf(varnishSampleConfig, defaultStats, kwAll)
 }
 
-func stringInSlice(str string, list []string) bool {
-	for _, v := range list {
-		if v == str {
+// Builds a filter function that will indicate whether a given stat should
+// be reported
+func (s *Varnish) statsFilter() func(string) bool {
+	stats := defaultStats
+	if len(s.Stats) > 0 {
+		stats = s.Stats
+	}
+
+	// Build a set for constant-time lookup of whether stats should be included
+	filter := make(map[string]struct{})
+	for _, s := range stats {
+		filter[s] = struct{}{}
+	}
+
+	// Create a function that respects the kwAll by always returning true
+	// if it is set
+	return func(stat string) bool {
+		if stats[0] == kwAll {
 			return true
 		}
+
+		_, found := filter[stat]
+		return found
 	}
-	return false
 }
 
-func (s *Varnish) Gather(acc telegraf.Accumulator) error {
-
-	sections := []string{"LCK", "MAIN", "MEMPOOL", "MGT", "SMA", "VBE"}
-	stats := []string{"MAIN.cache_hit", "MAIN.cache_miss", "MAIN.uptime",
-		"LCK.lru.locks", "LCK.smp.destroy",
-		"MEMPOOL.sess1.randry", "MEMPOOL.sess1.surplus",
-		"SMA.s0.c_freed"}
-	statsFilter := make(map[string]bool)
-
-	for _, s := range stats {
-		statsFilter[s] = true
-	}
-
-	sectionMap := make(map[string]map[string]interface{})
-
-	for _, s := range sections {
-		sectionMap[s] = make(map[string]interface{})
-	}
-
+// Shell out to varnish_stat and return the output
+func varnishStat() (*bytes.Buffer, error) {
 	cmdName := "/usr/bin/varnishstat"
 	cmdArgs := []string{"-1"}
 
@@ -69,10 +80,28 @@ func (s *Varnish) Gather(acc telegraf.Accumulator) error {
 	cmd.Stdout = &out
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("error running varnishstat: %s", err)
+		return &out, fmt.Errorf("error running varnishstat: %s", err)
 	}
 
-	scanner := bufio.NewScanner(&out)
+	return &out, nil
+}
+
+// Gather collects the configured stats from varnish_stat and adds them to the
+// Accumulator
+//
+// The prefix of each stat (eg MAIN, MEMPOOL, LCK, etc) will be used as a
+// 'section' tag and all stats that share that prefix will be reported as fields
+// with that tag
+func (s *Varnish) Gather(acc telegraf.Accumulator) error {
+
+	out, err := varnishStat()
+	if err != nil {
+		return fmt.Errorf("error gathering metrics: %s", err)
+	}
+
+	statsFilter := s.statsFilter()
+	sectionMap := make(map[string]map[string]interface{})
+	scanner := bufio.NewScanner(out)
 	for scanner.Scan() {
 		cols := strings.Fields(scanner.Text())
 		if len(cols) < 2 {
@@ -82,24 +111,26 @@ func (s *Varnish) Gather(acc telegraf.Accumulator) error {
 			continue
 		}
 
-		metric := cols[0]
+		stat := cols[0]
 		value := cols[1]
 
-		if !statsFilter[metric] {
+		if !statsFilter(stat) {
 			continue
 		}
 
-		parts := strings.SplitN(metric, ".", 2)
+		parts := strings.SplitN(stat, ".", 2)
 		section := parts[0]
 		field := parts[1]
 
-		// Only add the sections we care about
-		if _, ok := sectionMap[section]; ok {
-			sectionMap[section][field], err = strconv.Atoi(value)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Expected a numeric vlaue for %s = %v\n",
-					metric, value)
-			}
+		// Init the section if necessary
+		if _, ok := sectionMap[section]; !ok {
+			sectionMap[section] = make(map[string]interface{})
+		}
+
+		sectionMap[section][field], err = strconv.Atoi(value)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Expected a numeric vlaue for %s = %v\n",
+				stat, value)
 		}
 	}
 

--- a/varnish.go
+++ b/varnish.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/influxdata/telegraf"
@@ -43,48 +44,74 @@ func stringInSlice(str string, list []string) bool {
 
 func (s *Varnish) Gather(acc telegraf.Accumulator) error {
 
-	var stats []string
+	sections := []string{"LCK", "MAIN", "MEMPOOL", "MGT", "SMA", "VBE"}
+	stats := []string{"MAIN.cache_hit", "MAIN.cache_miss", "MAIN.uptime",
+		"LCK.lru.locks", "LCK.smp.destroy",
+		"MEMPOOL.sess1.randry", "MEMPOOL.sess1.surplus",
+		"SMA.s0.c_freed"}
+	statsFilter := make(map[string]bool)
 
-	if len(s.Stats) == 0 {
-		stats = []string{"MAIN.cache_hit", "MAIN.cache_miss", "MAIN.uptime"}
-	} else {
-		stats = s.Stats
+	for _, s := range stats {
+		statsFilter[s] = true
+	}
+
+	sectionMap := make(map[string]map[string]interface{})
+
+	for _, s := range sections {
+		sectionMap[s] = make(map[string]interface{})
 	}
 
 	cmdName := "/usr/bin/varnishstat"
 	cmdArgs := []string{"-1"}
 
 	cmd := exec.Command(cmdName, cmdArgs...)
-	cmdReader, err := cmd.StdoutPipe()
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error creating StdoutPipe for Cmd", err)
-		os.Exit(1)
+		return fmt.Errorf("error running varnishstat: %s", err)
 	}
 
-	scanner := bufio.NewScanner(cmdReader)
-	go func() {
-		for scanner.Scan() {
-			stat_line := strings.Fields(scanner.Text())
-			if stringInSlice(stat_line[0], stats) {
-				tmp := strings.Split(stat_line[0], ".")
-				sect := tmp[0]
-				subsect := tmp[1]
-				val := stat_line[1]
+	scanner := bufio.NewScanner(&out)
+	for scanner.Scan() {
+		cols := strings.Fields(scanner.Text())
+		if len(cols) < 2 {
+			continue
+		}
+		if !strings.Contains(cols[0], ".") {
+			continue
+		}
+
+		metric := cols[0]
+		value := cols[1]
+
+		if !statsFilter[metric] {
+			continue
+		}
+
+		parts := strings.SplitN(metric, ".", 2)
+		section := parts[0]
+		field := parts[1]
+
+		// Only add the sections we care about
+		if _, ok := sectionMap[section]; ok {
+			sectionMap[section][field], err = strconv.Atoi(value)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Expected a numeric vlaue for %s = %v\n",
+					metric, value)
 			}
 		}
-		acc.AddFields("varnish", fields, tags)
-	}()
-
-	err = cmd.Start()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error starting Cmd", err)
-		os.Exit(1)
 	}
 
-	err = cmd.Wait()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error waiting for Cmd", err)
-		os.Exit(1)
+	for section, fields := range sectionMap {
+		tags := map[string]string{
+			"section": section,
+		}
+		if len(fields) == 0 {
+			continue
+		}
+
+		acc.AddFields("varnish", fields, tags)
 	}
 
 	return nil


### PR DESCRIPTION
- Changed the call to varnishstat to be synchronous, in order to remove
  race condition
- Grouping metrics into sections based on the prefix of the line name
- Making one call to AddFields for each section
- Differentiating sections using tags
